### PR TITLE
Add proxy for sso ping

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,7 +19,7 @@ from proxy.user.views import (
     SignupProxyView,
     PasswordResetProxyView,
 )
-from proxy.healthcheck.views import HealthCheckAPIProxyView
+from proxy.healthcheck.views import HealthCheckAPIProxyView, PingAPIProxyView
 from proxy.oauth2.views_user import UserRetrieveAPIProxyView
 from proxy.oauth2.views import (
     AuthorizationProxyView,
@@ -118,6 +118,11 @@ api_urlpatterns = [
         r'^$',
         HealthCheckAPIProxyView.as_view(),
         name="health_check_proxy"
+    ),
+    url(
+        r'^ping/$',
+        PingAPIProxyView.as_view(),
+        name="ping_proxy"
     ),
     url(
         r'^session-user/$',

--- a/proxy/healthcheck/tests/test_views.py
+++ b/proxy/healthcheck/tests/test_views.py
@@ -9,3 +9,13 @@ def test_health_check_proxy_signed(signed_client):
 def test_session_user_proxy_unsigned(client):
     response = client.get(reverse('session_user_proxy'))
     assert response.status_code == 403
+
+
+def test_ping_proxy_proxy_signed(signed_client):
+    response = signed_client.get(reverse('ping_proxy'))
+    assert response.status_code == 200
+
+
+def test_ping_proxy_proxy_unsigned(client):
+    response = client.get(reverse('ping_proxy'))
+    assert response.status_code == 403

--- a/proxy/healthcheck/views.py
+++ b/proxy/healthcheck/views.py
@@ -3,3 +3,7 @@ from proxy.utils import CheckSignatureMixin, BaseProxyView
 
 class HealthCheckAPIProxyView(CheckSignatureMixin, BaseProxyView):
     pass
+
+
+class PingAPIProxyView(CheckSignatureMixin, BaseProxyView):
+    pass


### PR DESCRIPTION
[part of this task](https://uktrade.atlassian.net/browse/ED-2933)

Will not pass until [this PR](https://github.com/uktrade/directory-sso/pull/207) is merged 

This will be used by FAB to determine if FAB can communicate with API.

FAB is not using the healthcheck view because that has different permission requirements:
 - healthcheck: permission determined via querystring value
 - ping: permission determined via signature