### PR TITLE
Remove ipv6 from docker run command, does not work on the newest Amaz…

### DIFF
--- a/docker/cmd-webserver.sh
+++ b/docker/cmd-webserver.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -xe
 
-gunicorn config.wsgi --bind [::1]:$PORT --bind 0.0.0.0:$PORT
+gunicorn config.wsgi --bind 0.0.0.0:$PORT


### PR DESCRIPTION
…on ECS-optimized AMI amzn-ami-2017.09.e-amazon-ecs-optimized