### PR TITLE
(feat) Proxy X-Forwarded-For

### DIFF
--- a/proxy/user/tests/test_views.py
+++ b/proxy/user/tests/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.core.urlresolvers import reverse
+from django.test.client import Client
 import pytest
 import revproxy
 
@@ -10,35 +11,56 @@ def test_404(client):
     assert response.status_code == 404
 
 
+@pytest.fixture
+def no_remote_addr_client():
+    # The django test client _always_ populates REMOTE_ADDR
+    # However, in production this depends on the web-server
+    # environment, and we want to test the case when it's not
+    # set.
+    class NoRemoteAddrClient(Client):
+        def _base_environ(self, **request):
+            return {
+                key: value
+                for key, value in super()._base_environ(**request).items()
+                if key != 'REMOTE_ADDR'
+            }
+
+    return NoRemoteAddrClient()
+
+
 @pytest.mark.parametrize(
-    'get_kwargs,expected_x_forwarded_for',
+    'get_kwargs',
     (
         (
-            # If no X-Forwarded-For header, it is set to REMOTE_ADDR
+            # If neither X-Forwarded-For nor REMOTE_ADDR, then don't set
+            # X-Forwarded-For outgoing
             dict(
-                REMOTE_ADDR='4.3.2.1'
-            ),
-            '4.3.2.1',
+            )
         ),
         (
-            # If X-Forwarded-For header, REMOTE_ADDR is appended to it
+            # If only REMOTE_ADDR, then don't set X-Forwarded-For outgoing
             dict(
-                REMOTE_ADDR='4.3.2.1',
+                REMOTE_ADDR='4.3.2.1'
+            )
+        ),
+        (
+            # If only X-Forwarded-For incomding, then don't set
+            # X-Forwarded-For outgoing
+            dict(
                 HTTP_X_FORWARDED_FOR='1.2.3.4',
-            ),
-            '1.2.3.4, 4.3.2.1',
+            )
         ),
     ),
 )
-def test_x_forwarded_for(client, get_kwargs, expected_x_forwarded_for):
+def test_x_forwarded_for_not_set(no_remote_addr_client, get_kwargs):
     with patch('revproxy.views.HTTP_POOLS', wraps=revproxy.views.HTTP_POOLS) \
             as mock_pool_manager:
-        client.get('/anything/', **get_kwargs)
+        no_remote_addr_client.get('/anything/', **get_kwargs)
     headers = mock_pool_manager.urlopen.call_args[1]['headers']
-    assert headers['X-Forwarded-For'] == expected_x_forwarded_for
+    assert 'X-Forwarded-For' not in headers
 
 
-def test_if_x_forwarded_for_on_original_request_then_its_appended_to(client):
+def test_if_x_forwarded_for_and_remote_addr_then_are_concat_with_comma(client):
     with patch('revproxy.views.HTTP_POOLS', wraps=revproxy.views.HTTP_POOLS) \
             as mock_pool_manager:
         client.get('/anything/', REMOTE_ADDR='4.3.2.1',

--- a/proxy/user/tests/test_views.py
+++ b/proxy/user/tests/test_views.py
@@ -1,9 +1,50 @@
+from unittest.mock import patch
+
 from django.core.urlresolvers import reverse
+import pytest
+import revproxy
 
 
 def test_404(client):
     response = client.get('/asdf/')
     assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    'get_kwargs,expected_x_forwarded_for',
+    (
+        (
+            # If no X-Forwarded-For header, it is set to REMOTE_ADDR
+            dict(
+                REMOTE_ADDR='4.3.2.1'
+            ),
+            '4.3.2.1',
+        ),
+        (
+            # If X-Forwarded-For header, REMOTE_ADDR is appended to it
+            dict(
+                REMOTE_ADDR='4.3.2.1',
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            '1.2.3.4, 4.3.2.1',
+        ),
+    ),
+)
+def test_x_forwarded_for(client, get_kwargs, expected_x_forwarded_for):
+    with patch('revproxy.views.HTTP_POOLS', wraps=revproxy.views.HTTP_POOLS) \
+            as mock_pool_manager:
+        client.get('/anything/', **get_kwargs)
+    headers = mock_pool_manager.urlopen.call_args[1]['headers']
+    assert headers['X-Forwarded-For'] == expected_x_forwarded_for
+
+
+def test_if_x_forwarded_for_on_original_request_then_its_appended_to(client):
+    with patch('revproxy.views.HTTP_POOLS', wraps=revproxy.views.HTTP_POOLS) \
+            as mock_pool_manager:
+        client.get('/anything/', REMOTE_ADDR='4.3.2.1',
+                   HTTP_X_FORWARDED_FOR='1.2.3.4')
+    headers = mock_pool_manager.urlopen.call_args[1]['headers']
+    assert headers['X-Forwarded-For'] == '1.2.3.4, 4.3.2.1'
 
 
 def test_account_signup(client):

--- a/proxy/utils.py
+++ b/proxy/utils.py
@@ -55,6 +55,14 @@ class BaseProxyView(ProxyView):
             content_type=self.request_headers.get('Content-Type'),
         )
 
+        # Behave as a standard proxy, appending REMOTE_ADDR to the
+        # X-Forwarded-For header if it exists
+        meta = request.META
+        meta_x_fwd_for = 'HTTP_X_FORWARDED_FOR'
+        self.request_headers['X-Forwarded-For'] = \
+            (meta[meta_x_fwd_for] + ', ' if meta_x_fwd_for in meta else '') + \
+            request.META['REMOTE_ADDR']
+
         self.request_headers["X-Forwarded-Host"] = request.get_host()
         self.request_headers = {**self.request_headers, **signature_headers}
 

--- a/proxy/utils.py
+++ b/proxy/utils.py
@@ -39,6 +39,40 @@ class BaseProxyView(ProxyView):
     def get_upstream(self):
         return super(BaseProxyView, self).get_upstream(path=None)
 
+    def get_request_headers(self):
+        headers = super().get_request_headers()
+
+        # revproxy default behaviour copies X-Forwarded-For, which we
+        # don't want in order to only populate if we have both
+        # X-Forwarded-For and REMOTE_ADDR to keep the number of cases we
+        # _do_ populate X-Forwarded-For down
+        headers.pop('X-Forwarded-For', None)
+
+        meta = self.request.META
+        meta_x_fwd_for = 'HTTP_X_FORWARDED_FOR'
+        has_x_fwd_for = meta_x_fwd_for in meta
+        has_remote_addr = 'REMOTE_ADDR' in meta
+        if has_x_fwd_for and has_remote_addr:
+            headers['X-Forwarded-For'] = \
+                meta[meta_x_fwd_for] + ', ' + self.request.META['REMOTE_ADDR']
+
+        if not has_x_fwd_for:
+            self.log.error(
+                'HTTP_X_FORWARDED_FOR was missing from the request %s. '
+                'This is not expected: later IP whitelisting will fail.',
+                self.request,
+            )
+        if not has_remote_addr:
+            self.log.error(
+                'REMOTE_ADDR was missing from the request %s. '
+                'This is not expected: later IP whitelisting will fail.',
+                self.request,
+            )
+
+        headers["X-Forwarded-Host"] = self.request.get_host()
+
+        return headers
+
     def get_upstream_response(self, request, *args, **kwargs):
         request_payload = request.body
 
@@ -54,35 +88,6 @@ class BaseProxyView(ProxyView):
             method=request.method,
             content_type=self.request_headers.get('Content-Type'),
         )
-
-        # revproxy default behaviour copies X-Forwarded-For, which we
-        # don't want in order to only populate if we have both
-        # X-Forwarded-For and REMOTE_ADDR to keep the number of cases we
-        # _do_ populate X-Forwarded-For down
-        self.request_headers.pop('X-Forwarded-For', None)
-
-        meta = request.META
-        meta_x_fwd_for = 'HTTP_X_FORWARDED_FOR'
-        has_x_fwd_for = meta_x_fwd_for in meta
-        has_remote_addr = 'REMOTE_ADDR' in meta
-        if has_x_fwd_for and has_remote_addr:
-            self.request_headers['X-Forwarded-For'] = \
-                meta[meta_x_fwd_for] + ', ' + request.META['REMOTE_ADDR']
-
-        if not has_x_fwd_for:
-            self.log.error(
-                'HTTP_X_FORWARDED_FOR was missing from the request %s. '
-                'This is not expected: later IP whitelisting will fail.',
-                request,
-            )
-        if not has_remote_addr:
-            self.log.error(
-                'REMOTE_ADDR was missing from the request %s. '
-                'This is not expected: later IP whitelisting will fail.',
-                request,
-            )
-
-        self.request_headers["X-Forwarded-Host"] = request.get_host()
         self.request_headers = {**self.request_headers, **signature_headers}
 
         try:


### PR DESCRIPTION
This is so the target can retrieve the IP of the client, so it can whitelist
based on it. Note: the safety of this depends strongly the topology of the
system and how each proxy behaves. It cannot be used in general