### PR TITLE
Adopt Black auto-formatting + provide optional pre-commit config, incl isort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
         command: |
           python3 -m venv .venv
           . .venv/bin/activate
-          pip install black
+          pip install flake8
           flake8 . --exclude=migrations,.venv
 
   black:
@@ -54,11 +54,11 @@ jobs:
         command: |
           python3 -m venv .venv
           . .venv/bin/activate
-          pip install flake8
+          pip install black
           black ./ --check
 
 workflows:
-  version: 3
+  version: 2
   test_and_code_checks:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,28 @@ jobs:
         command: |
           python3 -m venv .venv
           . .venv/bin/activate
-          pip install flake8
+          pip install black
           flake8 . --exclude=migrations,.venv
 
+  black:
+    docker:
+    - image: circleci/python:3.6.6
+    steps:
+    - checkout
+    - setup_remote_docker:
+        docker_layer_caching: true
+    - run:
+        name: Run Black in check mode
+        command: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install flake8
+          black ./ --check
+
 workflows:
-  version: 2
-  test_and_flake8:
+  version: 3
+  test_and_code_checks:
     jobs:
       - test
       - flake8
+      - black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
       rev: 20.8b1
       hooks:
           - id: black
-            args: ["--skip-string-normalization", "--line-length=120"]
+          # Config for black lives in pyproject.toml
     - repo: https://github.com/asottile/blacken-docs
       rev: v1.6.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+    - repo: https://github.com/psf/black
+      rev: 20.8b1
+      hooks:
+          - id: black
+            args: ["--skip-string-normalization", "--line-length=120"]
+    - repo: https://github.com/asottile/blacken-docs
+      rev: v1.6.0
+      hooks:
+          - id: blacken-docs
+            additional_dependencies: [black==20.8b1]
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.6.4
+      hooks:
+          - id: isort
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+          - id: flake8
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.3.0
+      hooks:
+          - id: trailing-whitespace
+            args: ["--markdown-linebreak-ext=md,markdown"]
+          - id: end-of-file-fixer
+          - id: check-yaml
+          - id: check-added-large-files
+          # - id: fix-encoding-pragma
+          - id: check-ast
+          - id: check-byte-order-marker
+          - id: check-merge-conflict
+          - id: debug-statements
+          - id: detect-private-key
+# -   repo: https://github.com/pre-commit/pygrep-hooks
+#     rev: v1.7.0
+#     hooks:
+#     -   id: python-use-type-annotations
+#     -   id: python-no-eval
+#     -   id: python-no-log-warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Pre release
 
+### Enhancements
+
+
 ## Hotfix
 - No ticket - v3-cipipeline manifest.yml file fix
 
 ### Enhancements
+- GP2-1068 - adopt Black auto-formatting + provide optional pre-commit config
 
 ### Bug fixes
 - No ticket - Fix for codecov status not returning

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -2,7 +2,6 @@ import environ
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-
 env = environ.Env()
 for env_file in env.list('ENV_FILES', default=[]):
     env.read_env(f'conf/env/{env_file}')
@@ -14,10 +13,7 @@ DEBUG = env.bool('DEBUG', False)
 # PaaS, we can open ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 
-INSTALLED_APPS = [
-    'revproxy',
-    'core'
-]
+INSTALLED_APPS = ['revproxy', 'core']
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -37,37 +33,18 @@ if DEBUG:
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
-        'filters': {
-            'require_debug_false': {
-                '()': 'django.utils.log.RequireDebugFalse'
-            }
-        },
-        'handlers': {
-            'console': {
-                'level': 'DEBUG',
-                'class': 'logging.StreamHandler',
-            },
-        },
+        'filters': {'require_debug_false': {'()': 'django.utils.log.RequireDebugFalse'}},
+        'handlers': {'console': {'level': 'DEBUG', 'class': 'logging.StreamHandler'}},
         'loggers': {
-            'django.request': {
-                'handlers': ['console'],
-                'level': 'ERROR',
-                'propagate': True,
-            },
-            '': {
-                'handlers': ['console'],
-                'level': 'DEBUG',
-                'propagate': False,
-            },
-        }
+            'django.request': {'handlers': ['console'], 'level': 'ERROR', 'propagate': True},
+            '': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
+        },
     }
 
 # Sentry
 if env.str('SENTRY_DSN', ''):
     sentry_sdk.init(
-        dsn=env.str('SENTRY_DSN'),
-        environment=env.str('SENTRY_ENVIRONMENT'),
-        integrations=[DjangoIntegration()]
+        dsn=env.str('SENTRY_DSN'), environment=env.str('SENTRY_ENVIRONMENT'), integrations=[DjangoIntegration()]
     )
 
 

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -2,7 +2,4 @@ from django.conf.urls import url
 
 import core.views
 
-
-urlpatterns = [
-    url(r'', core.views.ProxyView.as_view())
-]
+urlpatterns = [url(r'', core.views.ProxyView.as_view())]

--- a/conftest.py
+++ b/conftest.py
@@ -1,20 +1,20 @@
-from http.cookies import SimpleCookie
+# from http.cookies import SimpleCookie
 
-import pytest
-from mohawk import Sender
+# import pytest
+# from mohawk import Sender
 
 
-@pytest.fixture
-def authenticated_client(client, settings):
-    sender = Sender(
-        credentials={
-            'id': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_ID,
-            'key': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_SECRET,
-            'algorithm': 'sha256',
-        },
-        url='/',
-        method='',
-        always_hash_content=False,
-    )
-    client.cookies = SimpleCookie({'ip-restrict-signature': sender.request_header})
-    return client
+# @pytest.fixture
+# def authenticated_client(client, settings):
+#     sender = Sender(
+#         credentials={
+#             'id': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_ID,
+#             'key': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_SECRET,
+#             'algorithm': 'sha256',
+#         },
+#         url='/',
+#         method='',
+#         always_hash_content=False,
+#     )
+#     client.cookies = SimpleCookie({'ip-restrict-signature': sender.request_header})
+#     return client

--- a/conftest.py
+++ b/conftest.py
@@ -1,22 +1,20 @@
-from mohawk import Sender
-import pytest
-
 from http.cookies import SimpleCookie
+
+import pytest
+from mohawk import Sender
 
 
 @pytest.fixture
 def authenticated_client(client, settings):
     sender = Sender(
-         credentials={
-             'id': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_ID,
-             'key': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_SECRET,
-             'algorithm': 'sha256'
-         },
-         url='/',
-         method='',
-         always_hash_content=False
-     )
-    client.cookies = SimpleCookie({
-        'ip-restrict-signature': sender.request_header
-    })
+        credentials={
+            'id': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_ID,
+            'key': settings.TEST_IP_RESTRICTOR_SKIP_SENDER_SECRET,
+            'algorithm': 'sha256',
+        },
+        url='/',
+        method='',
+        always_hash_content=False,
+    )
+    client.cookies = SimpleCookie({'ip-restrict-signature': sender.request_header})
     return client

--- a/core/signature.py
+++ b/core/signature.py
@@ -1,9 +1,4 @@
+from django.conf import settings
 from sigauth.helpers import RequestSigner
 
-from django.conf import settings
-
-
-sso_signer = RequestSigner(
-    settings.SSO_SIGNATURE_SECRET,
-    sender_id='directory',
-)
+sso_signer = RequestSigner(settings.SSO_SIGNATURE_SECRET, sender_id='directory')

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -1,11 +1,10 @@
 import json
 from unittest import mock
-import urllib3.response
 
 import pytest
 import revproxy
 import revproxy.views
-
+import urllib3.response
 from django.test.client import Client
 
 
@@ -17,11 +16,7 @@ def no_remote_addr_client():
     # set.
     class NoRemoteAddrClient(Client):
         def _base_environ(self, **request):
-            return {
-                key: value
-                for key, value in super()._base_environ(**request).items()
-                if key != 'REMOTE_ADDR'
-            }
+            return {key: value for key, value in super()._base_environ(**request).items() if key != 'REMOTE_ADDR'}
 
     return NoRemoteAddrClient()
 
@@ -35,15 +30,18 @@ def mock_response():
     )
 
 
-@pytest.mark.parametrize('get_kwargs', (
-    # If neither X-Forwarded-For nor REMOTE_ADDR, then don't set
-    # X-Forwarded-For outgoing
-    {},
-    {'REMOTE_ADDR': '4.3.2.1'},
-    # If only X-Forwarded-For incomding, then don't set
-    # X-Forwarded-For outgoing
-    {'HTTP_X_FORWARDED_FOR': '1.2.3.4'},
-))
+@pytest.mark.parametrize(
+    'get_kwargs',
+    (
+        # If neither X-Forwarded-For nor REMOTE_ADDR, then don't set
+        # X-Forwarded-For outgoing
+        {},
+        {'REMOTE_ADDR': '4.3.2.1'},
+        # If only X-Forwarded-For incomding, then don't set
+        # X-Forwarded-For outgoing
+        {'HTTP_X_FORWARDED_FOR': '1.2.3.4'},
+    ),
+)
 @mock.patch('urllib3.poolmanager.PoolManager.urlopen')
 def test_x_forwarded_for_not_set(mock_urlopen, no_remote_addr_client, get_kwargs, settings, mock_response):
     settings.FEATURE_URL_PREFIX_ENABLED = True
@@ -63,11 +61,7 @@ def test_if_x_forwarded_for_and_remote_addr_then_are_concat_with_comma(mock_urlo
 
     stub = mock.patch('revproxy.views.HTTP_POOLS', wraps=revproxy.views.HTTP_POOLS)
     with stub as mock_pool_manager:
-        client.get(
-            '/sso/accounts/login/',
-            REMOTE_ADDR='4.3.2.1',
-            HTTP_X_FORWARDED_FOR='1.2.3.4',
-        )
+        client.get('/sso/accounts/login/', REMOTE_ADDR='4.3.2.1', HTTP_X_FORWARDED_FOR='1.2.3.4')
 
     headers = mock_pool_manager.urlopen.call_args[1]['headers']
     assert headers['X-Forwarded-For'] == '1.2.3.4, 4.3.2.1'

--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,8 @@
-import urllib3
-
-from revproxy.response import get_django_response
 import revproxy.views
-
+import urllib3
 from django.conf import settings
 from django.shortcuts import redirect
+from revproxy.response import get_django_response
 
 from core import signature
 
@@ -96,12 +94,9 @@ class ProxyView(revproxy.views.ProxyView):
                 headers=self.request_headers,
                 body=request_payload,
                 decode_content=False,
-                preload_content=False
+                preload_content=False,
             )
-            self.log.debug(
-                'Proxy response header: %s',
-                upstream_response.getheaders()
-            )
+            self.log.debug('Proxy response header: %s', upstream_response.getheaders())
         except urllib3.exceptions.HTTPError as error:
             self.log.exception(error)
             raise

--- a/makefile
+++ b/makefile
@@ -10,6 +10,15 @@ install_requirements:
 manage:
 	ENV_FILES='secrets-do-not-commit,dev' ./manage.py $(ARGUMENTS)
 
+autoformat:
+	# configuration for black is in pyproject.toml
+	black ./
+
+checks:
+	flake8 ./
+	# configuration for black is in pyproject.toml
+	black ./ --check
+
 pytest:
 	ENV_FILES='test,dev' pytest $(ARGUMENTS)
 
@@ -24,4 +33,4 @@ secrets:
 webserver:
 	ENV_FILES='secrets-do-not-commit,dev' python manage.py runserver 0.0.0.0:8004 $(ARGUMENTS)
 
-.PHONY: clean install_requirements manage pytest requirements webserver
+.PHONY: autoformat clean install_requirements manage preflight pytest requirements webserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.circleci
+    | \.github
+    | \.pytest_cache
+    | \.venv
+    | \.vscode
+    | venv
+  )/
+  | manage.py       # also separately exclude a file in the root of the project
+)
+'''

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==2.2.10
+django==2.2.17
 django-revproxy==0.9.15
 django-environ==0.4.5
 sentry-sdk==0.13.4
@@ -8,3 +8,4 @@ requests[security]==2.22.0
 urllib3>=1.24.2,<2.0.0
 djangorestframework==3.11.0
 directory-components==35.9.1
+cryptography>=3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,20 @@
 #
 #    pip-compile requirements.in
 #
-asn1crypto==0.24.0        # via cryptography
 attrs==19.3.0             # via jsonschema
 beautifulsoup4==4.8.2     # via directory-components
 certifi==2017.7.27.1      # via requests, sentry-sdk
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.4.1       # via pyopenssl, requests
+cryptography==3.2.1       # via -r requirements.in, pyopenssl, requests
 directory-components==35.9.1  # via -r requirements.in
 directory-constants==20.10.0  # via directory-components
 django-environ==0.4.5     # via -r requirements.in
 django-revproxy==0.9.15   # via -r requirements.in
-django==2.2.10            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
+django==2.2.17            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
 djangorestframework==3.11.0  # via -r requirements.in, sigauth
 gunicorn==20.0.4          # via -r requirements.in
-idna==2.6                 # via cryptography, requests
+idna==2.6                 # via requests
 importlib-metadata==1.3.0  # via jsonschema
 jsonschema==3.2.0         # via directory-components
 mohawk==0.3.4             # via sigauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,13 @@ certifi==2017.7.27.1      # via requests, sentry-sdk
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==2.4.1       # via pyopenssl, requests
-directory-components==35.9.1
+directory-components==35.9.1  # via -r requirements.in
 directory-constants==20.10.0  # via directory-components
-django-environ==0.4.5
-django-revproxy==0.9.15
-django==2.2.10
-djangorestframework==3.11.0
-gunicorn==20.0.4
+django-environ==0.4.5     # via -r requirements.in
+django-revproxy==0.9.15   # via -r requirements.in
+django==2.2.10            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
+djangorestframework==3.11.0  # via -r requirements.in, sigauth
+gunicorn==20.0.4          # via -r requirements.in
 idna==2.6                 # via cryptography, requests
 importlib-metadata==1.3.0  # via jsonschema
 jsonschema==3.2.0         # via directory-components
@@ -27,11 +27,14 @@ pycparser==2.19           # via cffi
 pyopenssl==18.0.0         # via requests
 pyrsistent==0.15.6        # via jsonschema
 pytz==2017.2              # via django
-requests[security]==2.22.0
-sentry-sdk==0.13.4
-sigauth==4.1.1
+requests[security]==2.22.0  # via -r requirements.in
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via -r requirements.in
 six==1.11.0               # via cryptography, jsonschema, mohawk, pyopenssl, pyrsistent
 soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0           # via django
-urllib3==1.24.2
+urllib3==1.24.2           # via -r requirements.in, django-revproxy, requests, sentry-sdk
 zipp==0.6.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,8 +1,14 @@
 -r requirements.in
 
 codecov==2.1.7
-flake8
 pytest
 pytest-cov
 pytest-django
 pytest-sugar
+
+# Pinned because pre-commit features specific versions
+black==20.8b1
+blacken-docs==1.6.0
+isort==5.6.4
+flake8==3.3.0
+pre-commit-hooks==3.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,50 +4,67 @@
 #
 #    pip-compile requirements_test.in
 #
+appdirs==1.4.4            # via black
 attrs==19.3.0             # via jsonschema, pytest
 beautifulsoup4==4.8.2     # via directory-components
+black==20.8b1             # via -r requirements_test.in, blacken-docs
+blacken-docs==1.6.0       # via -r requirements_test.in
 certifi==2019.9.11        # via requests, sentry-sdk
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
-codecov==2.1.7
+click==7.1.2              # via black
+codecov==2.1.7            # via -r requirements_test.in
 coverage==4.5.4           # via codecov, pytest-cov
 cryptography==2.8         # via pyopenssl, requests
-directory-components==35.9.1
+dataclasses==0.8          # via black
+directory-components==35.9.1  # via -r requirements.in
 directory-constants==20.10.0  # via directory-components
-django-environ==0.4.5
-django-revproxy==0.9.15
-django==2.2.10
-djangorestframework==3.11.0
-entrypoints==0.3          # via flake8
-flake8==3.7.9
-gunicorn==20.0.4
+django-environ==0.4.5     # via -r requirements.in
+django-revproxy==0.9.15   # via -r requirements.in
+django==2.2.10            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
+djangorestframework==3.11.0  # via -r requirements.in, sigauth
+flake8==3.3.0             # via -r requirements_test.in
+gunicorn==20.0.4          # via -r requirements.in
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest
+isort==5.6.4              # via -r requirements_test.in
 jsonschema==3.2.0         # via directory-components
 mccabe==0.6.1             # via flake8
 mohawk==0.3.4             # via sigauth
 more-itertools==7.2.0     # via pytest, zipp
+mypy-extensions==0.4.3    # via black
 packaging==19.2           # via pytest, pytest-sugar
+pathspec==0.8.1           # via black
 pluggy==0.13.1            # via pytest
+pre-commit-hooks==3.3.0   # via -r requirements_test.in
 py==1.8.0                 # via pytest
-pycodestyle==2.5.0        # via flake8
+pycodestyle==2.3.1        # via flake8
 pycparser==2.19           # via cffi
-pyflakes==2.1.1           # via flake8
+pyflakes==1.5.0           # via flake8
 pyopenssl==19.1.0         # via requests
 pyparsing==2.4.5          # via packaging
 pyrsistent==0.15.6        # via jsonschema
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest-sugar==0.9.2
-pytest==5.3.1
+pytest-cov==2.8.1         # via -r requirements_test.in
+pytest-django==3.7.0      # via -r requirements_test.in
+pytest-sugar==0.9.2       # via -r requirements_test.in
+pytest==5.3.1             # via -r requirements_test.in, pytest-cov, pytest-django, pytest-sugar
 pytz==2019.3              # via django
-requests[security]==2.22.0
-sentry-sdk==0.13.4
-sigauth==4.1.1
+regex==2020.11.13         # via black
+requests[security]==2.22.0  # via -r requirements.in, codecov
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via pre-commit-hooks
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via -r requirements.in
 six==1.13.0               # via cryptography, jsonschema, mohawk, packaging, pyopenssl, pyrsistent
 soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via pytest-sugar
-urllib3==1.24.3
+toml==0.10.2              # via black, pre-commit-hooks
+typed-ast==1.4.1          # via black
+typing-extensions==3.7.4.3  # via black
+urllib3==1.24.3           # via -r requirements.in, django-revproxy, requests, sentry-sdk
 wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,13 +15,13 @@ chardet==3.0.4            # via requests
 click==7.1.2              # via black
 codecov==2.1.7            # via -r requirements_test.in
 coverage==4.5.4           # via codecov, pytest-cov
-cryptography==2.8         # via pyopenssl, requests
+cryptography==3.2.1       # via -r requirements.in, pyopenssl, requests
 dataclasses==0.8          # via black
 directory-components==35.9.1  # via -r requirements.in
 directory-constants==20.10.0  # via directory-components
 django-environ==0.4.5     # via -r requirements.in
 django-revproxy==0.9.15   # via -r requirements.in
-django==2.2.10            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
+django==2.2.17            # via -r requirements.in, directory-components, directory-constants, django-revproxy, djangorestframework, sigauth
 djangorestframework==3.11.0  # via -r requirements.in, sigauth
 flake8==3.3.0             # via -r requirements_test.in
 gunicorn==20.0.4          # via -r requirements.in
@@ -31,7 +31,7 @@ isort==5.6.4              # via -r requirements_test.in
 jsonschema==3.2.0         # via directory-components
 mccabe==0.6.1             # via flake8
 mohawk==0.3.4             # via sigauth
-more-itertools==7.2.0     # via pytest, zipp
+more-itertools==7.2.0     # via pytest
 mypy-extensions==0.4.3    # via black
 packaging==19.2           # via pytest, pytest-sugar
 pathspec==0.8.1           # via black
@@ -55,7 +55,7 @@ ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via pre-commit-hooks
 sentry-sdk==0.13.4        # via -r requirements.in
 sigauth==4.1.1            # via -r requirements.in
-six==1.13.0               # via cryptography, jsonschema, mohawk, packaging, pyopenssl, pyrsistent
+six==1.13.0               # via cryptography, jsonschema, mohawk, packaging, pyopenssl
 soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via pytest-sugar


### PR DESCRIPTION
This changeset:

* adds Black and related deps to test requirements
* adds minimal Black config in pyproject.toml which will be used by default
* adds makefile commands to use black in check or write mode (`make checks` or `make autoformat`)
* updates CI config to run `black --check` in CI, too
* adds `.pre-commit-config.yaml` for pre-commit (see pre-commit.com) which runs `isort`, too
* has applied `black` formatting to the entire codebase
* bumps the versions of `Django` and `cryptography`, as per Dependabot prompts.

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X]  Requirements have been compiled.
 - [X]  Security patches/releases applied.
 - [X]  Reviewers may merge after approval