### PR TITLE
Bump django to 4.1.13

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==4.1.10
+django==4.1.13
 django-revproxy-fix==0.10.1
 django-environ==0.10.0
 sentry-sdk==1.14.0
@@ -7,7 +7,7 @@ sigauth==5.2.0
 requests[security]==2.31.0
 urllib3>=1.26.18,<2.0.0
 djangorestframework==3.14.0
-directory-components==39.1.3
+directory-components==39.1.4
 cryptography>=41.0.3
 certifi==2023.7.22
 sqlparse==0.4.4 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,11 +21,11 @@ charset-normalizer==3.1.0
     # via requests
 cryptography==41.0.4
     # via -r requirements.in
-directory-components==39.1.3
+directory-components==39.1.4
     # via -r requirements.in
 directory-constants==23.1.0
     # via directory-components
-django==4.1.10
+django==4.1.13
     # via
     #   -r requirements.in
     #   directory-components
@@ -56,7 +56,9 @@ pyrsistent==0.15.6
 pytz==2023.3
     # via djangorestframework
 requests[security]==2.31.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   requests
 sentry-sdk==1.14.0
     # via -r requirements.in
 sigauth==5.2.0
@@ -65,6 +67,7 @@ six==1.11.0
     # via
     #   jsonschema
     #   mohawk
+    #   pyrsistent
 soupsieve==1.9.5
     # via beautifulsoup4
 sqlparse==0.4.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -31,15 +31,16 @@ click==8.1.3
     # via black
 coverage[toml]==7.2.3
     # via
+    #   coverage
     #   pytest-codecov
     #   pytest-cov
 cryptography==41.0.4
     # via -r requirements.in
-directory-components==39.1.3
+directory-components==39.1.4
     # via -r requirements.in
 directory-constants==23.1.0
     # via directory-components
-django==4.1.10
+django==4.1.13
     # via
     #   -r requirements.in
     #   directory-components
@@ -123,6 +124,7 @@ requests[security]==2.31.0
     # via
     #   -r requirements.in
     #   pytest-codecov
+    #   requests
 ruamel-yaml==0.17.21
     # via pre-commit-hooks
 ruamel-yaml-clib==0.2.7
@@ -135,6 +137,7 @@ six==1.13.0
     # via
     #   jsonschema
     #   mohawk
+    #   pyrsistent
 smmap==5.0.0
     # via gitdb
 soupsieve==1.9.5


### PR DESCRIPTION
Bump django to 4.1.13

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.