### PR TITLE
Bump cryptography to 42.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ urllib3>=1.26.18,<2.0.0
 djangorestframework==3.14.0
 directory-constants==24.1.0
 directory-components==40.1.1
-cryptography>=41.0.7
+cryptography>=42.0.0
 certifi==2023.7.22
 sqlparse==0.4.4 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ cffi==1.14.5
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==41.0.7
+cryptography==42.0.2
     # via -r requirements.in
 directory-components==40.1.1
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -34,7 +34,7 @@ coverage[toml]==7.2.3
     #   coverage
     #   pytest-codecov
     #   pytest-cov
-cryptography==41.0.7
+cryptography==42.0.2
     # via -r requirements.in
 directory-components==40.1.1
     # via -r requirements.in


### PR DESCRIPTION
Bump cryptography to 42.0.0

 - [x] Change has a jira ticket that has the correct status (KLS-1955)
