### PR TITLE
Bump cryptography to 43.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ djangorestframework==3.15.2
 directory-constants==24.1.3
 directory-components==40.2.3
 directory-healthcheck==3.7
-cryptography>=42.0.0
+cryptography>=43.0.1
 certifi==2024.07.04
 sqlparse==0.5.0
 setuptools<72

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.1.0
     # via requests
-cryptography==42.0.4
+cryptography==43.0.1
     # via -r requirements.in
 directory-components==40.2.3
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -33,7 +33,7 @@ coverage[toml]==7.2.3
     # via
     #   pytest-codecov
     #   pytest-cov
-cryptography==42.0.4
+cryptography==43.0.1
     # via -r requirements.in
 directory-components==40.2.3
     # via -r requirements.in


### PR DESCRIPTION
Bump cryptography to 43.0.1

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.

